### PR TITLE
fix: disable auto-anchoring announcements in API

### DIFF
--- a/src/api/announcements.php
+++ b/src/api/announcements.php
@@ -1,5 +1,5 @@
 <?php 
     include "../inc/announcements.php";
-    $announcements_array = getAnnounceArray();
+    $announcements_array = getAnnounceArray(false);
     $res = array("announcements" => $announcements_array);
     echo json_encode($res);

--- a/src/inc/announcements.php
+++ b/src/inc/announcements.php
@@ -4,7 +4,7 @@ function anchor($string)
     $reg_pattern = "/(((http|https|ftp|ftps)\:\/\/)|(www\.))[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(\:[0-9]+)?(\/\S*)?/";
     return preg_replace($reg_pattern, '<a href="$0" target="_blank" >$0</a>', $string);
 }
-function getAnnounceArray()
+function getAnnounceArray($anchor=true)
 {
     $username=getenv('HTTP_DB_USER');
     $password=getenv('HTTP_DB_PASS');
@@ -19,7 +19,11 @@ function getAnnounceArray()
     $announcements_array = array();
     if ($Result) {
         while ($row = $Result->fetch_array(MYSQLI_ASSOC)) {
-            array_push($announcements_array, $row["Groupteam"]." - ".anchor($row["Announce"]));
+            if ($anchor) {
+                array_push($announcements_array, $row["Groupteam"]." - ".anchor($row["Announce"]));
+            } else {
+                array_push($announcements_array, $row["Groupteam"]." - ".$row["Announce"]);
+            }
         }
     }
     if (empty($announcements_array)) {


### PR DESCRIPTION
<!--
  The title of your PR should follow the conventional commit template:
  https://www.conventionalcommits.org/en/v1.0.0/#summary

  ie:
  - feat: implement Google Analytics
  - style: formatted index.php
  - chore: updated gitignore

  See here for pr title examples types:
  https://github.com/commitizen/conventional-commit-types/blob/master/index.json
 -->

<!--
  Note: Although there are no restrictions on merging directly, please do try to get someone to look over your code.
        Or at the very least look it over yourself one more time before merging.

  Please DO NOT merge if you have failing checks! PR title fails are the easiest to fix.
 -->

**Pull Request Description**

<!--
  Provide a brief description/context for this pull request and the work done.
  This makes it easier to reread in the future and navigate the repo.
 -->
Fixed bug in announcements API causing links in announcements to be presented with anchor tags